### PR TITLE
hal: spkr_protection: compilation error fixes with the vndk

### DIFF
--- a/hal/audio_extn/spkr_protection.c
+++ b/hal/audio_extn/spkr_protection.c
@@ -54,6 +54,7 @@
 #define LOG_MASK HAL_MOD_FILE_SPKR_PROT
 #include <log_utils.h>
 #endif
+#include <pthread.h>
 
 #ifdef SPKR_PROT_ENABLED
 


### PR DESCRIPTION
* Tested on a msm8996 device with:
	BOARD_VNDK_VERSION := current
	AUDIO_FEATURE_ENABLED_SPKR_PROTECTION := true

Change-Id: Ia338b28056dfba1dc4b8169e206cdf02d6eeff32
Signed-off-by: Vladimir Oltean <olteanv@gmail.com>
Signed-off-by: Davide Garberi <dade.garberi@gmail.com>