### PR TITLE
audio_extn: Fix unused parameter warning in utils.c

### DIFF
--- a/hal/audio_extn/audio_extn.h
+++ b/hal/audio_extn/audio_extn.h
@@ -681,7 +681,12 @@ bool audio_extn_utils_is_dolby_format(audio_format_t format);
 int audio_extn_utils_get_bit_width_from_string(const char *);
 int audio_extn_utils_get_sample_rate_from_string(const char *);
 int audio_extn_utils_get_channels_from_string(const char *);
+
+#if !defined(DEV_ARBI_ENABLED) && !defined(SOUND_TRIGGER_ENABLED) && !defined(AUDIO_LISTEN_ENABLED)
+#define audio_extn_utils_release_snd_device(snd_device) (0)
+#else
 void audio_extn_utils_release_snd_device(snd_device_t snd_device);
+#endif
 
 #ifdef DS2_DOLBY_DAP_ENABLED
 #define LIB_DS2_DAP_HAL "vendor/lib/libhwdaphal.so"

--- a/hal/audio_extn/utils.c
+++ b/hal/audio_extn/utils.c
@@ -2519,6 +2519,7 @@ int audio_extn_utils_get_channels_from_string(const char *id_string)
     return -EINVAL;
 }
 
+#if defined(DEV_ARBI_ENABLED) || defined(SOUND_TRIGGER_ENABLED) || defined(AUDIO_LISTEN_ENABLED)
 void audio_extn_utils_release_snd_device(snd_device_t snd_device)
 {
     audio_extn_dev_arbi_release(snd_device);
@@ -2527,3 +2528,4 @@ void audio_extn_utils_release_snd_device(snd_device_t snd_device)
     audio_extn_listen_update_device_status(snd_device,
                                     LISTEN_EVENT_SND_DEVICE_FREE);
 }
+#endif


### PR DESCRIPTION
The unused parameter warning appears if we are not building with
at least one of the following cflags enabled:

* DEV_ARBI_ENABLED
* SOUND_TRIGGER_ENABLED
* AUDIO_LISTEN_ENABLED

  hardware/qcom/audio/hal/audio_extn/utils.c:2522:55: error: unused parameter 'snd_device'
[-Werror,-Wunused-parameter]
  void audio_extn_utils_release_snd_device(snd_device_t snd_device)
                                                      ^

Change-Id: I694c683c9bfde60343f0f6ea8d806bc5e24437e6