### PR TITLE
post_proc: Mark unused variables as __unused

### DIFF
--- a/post_proc/bundle.c
+++ b/post_proc/bundle.c
@@ -457,14 +457,14 @@ int offload_effects_bundle_set_hpx_state(bool hpx_state)
  * but the interface itself can be utilized for any effect.
  */
 __attribute__ ((visibility ("default")))
-void offload_effects_bundle_get_parameters(struct str_parms *query,
-                                           struct str_parms *reply)
+void offload_effects_bundle_get_parameters(__unused struct str_parms *query,
+                                           __unused struct str_parms *reply)
 {
     asphere_get_parameters(query, reply);
 }
 
 __attribute__ ((visibility ("default")))
-void offload_effects_bundle_set_parameters(struct str_parms *parms)
+void offload_effects_bundle_set_parameters(__unused struct str_parms *parms)
 {
     asphere_set_parameters(parms);
 }


### PR DESCRIPTION
Change-Id: Iabad50e504b32c18daa5387f50d4ed1c2a7d9c28